### PR TITLE
Added protecc init

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -34,6 +34,7 @@ ptyprocess==0.7.0
 Pygments==2.7.4
 pyre-check==0.0.59
 pyre-extensions==0.0.20
+python-dotenv==0.15.0
 pywatchman==1.4.1
 PyYAML==5.4.1
 Rx==1.6.1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import setup, find_packages
+
+setup(
+    name='protecc',
+    version='0.1',
+    packages=find_packages(),
+    include_package_data=True,
+    install_requires=[
+        # TODO add other dependencies here
+        'Click',
+    ],
+    entry_points='''
+        [console_scripts]
+        protecc=src.commands:protecc
+    ''',
+)

--- a/src/commands.py
+++ b/src/commands.py
@@ -7,11 +7,6 @@ def protecc():
     pass
 
 @protecc.command()
-def hello():
-    """Example script."""
-    click.echo('Hello World!')
-
-@protecc.command()
 @click.option("--config-path", default="./config", show_default=True, type=click.Path())
 def init(config_path):
     """

--- a/src/commands.py
+++ b/src/commands.py
@@ -17,13 +17,10 @@ def init(config_path):
     """
     Initializes the project folder with .pysa and taint.config files
     """
-    if os.path.isdir(config_path):
-        click.echo("Configuration already exists")
-        return
     click.echo("Initializing...")
-    os.mkdir(config_path)
+    if not os.path.isdir(config_path):
+        os.mkdir(config_path)
     model_path = os.path.join(config_path, "models.pysa")
-    print(model_path)
     if os.path.isfile(model_path):
         click.echo("models.pysa already exists...")
     else:
@@ -37,4 +34,4 @@ def init(config_path):
         with open(taint_config_path, 'w') as fp:
             pass
         click.echo("Create taint.config file...")
-    click.echo(f"Configuration files generated at {config_path}")
+    click.echo(f"Configuration files generated at '{config_path}'")

--- a/src/commands.py
+++ b/src/commands.py
@@ -28,11 +28,8 @@ taint_content = {
 }
 
 model_content = """
-django.http.request.HttpRequest.GET: TaintSource[Secret] = ...
-
-def eval(__source: TaintSink[Endpoint], __globals, __locals): ...
-
-def subprocess.getoutput(cmd: TaintSink[Endpoint]): ...
+protecc.vortex.Vortex.SECRETS: TaintSource[Secret]
+protecc.vortex.Vortex.endpoints: TaintSink[Endpoint]
 """
 
 @click.group()

--- a/src/commands.py
+++ b/src/commands.py
@@ -1,0 +1,40 @@
+import click
+import subprocess
+import os
+
+@click.group()
+def protecc():
+    pass
+
+@protecc.command()
+def hello():
+    """Example script."""
+    click.echo('Hello World!')
+
+@protecc.command()
+@click.option("--config-path", default="./config", show_default=True, type=click.Path())
+def init(config_path):
+    """
+    Initializes the project folder with .pysa and taint.config files
+    """
+    if os.path.isdir(config_path):
+        click.echo("Configuration already exists")
+        return
+    click.echo("Initializing...")
+    os.mkdir(config_path)
+    model_path = os.path.join(config_path, "models.pysa")
+    print(model_path)
+    if os.path.isfile(model_path):
+        click.echo("models.pysa already exists...")
+    else:
+        with open(model_path, 'w') as fp:
+            pass
+        click.echo("Created models.pysa file...")
+    taint_config_path = os.path.join(config_path, 'taint.config')
+    if os.path.isfile(taint_config_path):
+        click.echo("taint.config already exists...")
+    else:
+        with open(taint_config_path, 'w') as fp:
+            pass
+        click.echo("Create taint.config file...")
+    click.echo(f"Configuration files generated at {config_path}")

--- a/src/vortex.py
+++ b/src/vortex.py
@@ -1,4 +1,5 @@
 from dotenv import find_dotenv, dotenv_values
+import yaml
 
 
 class Vortex:
@@ -6,11 +7,16 @@ class Vortex:
         self.SECRETS = {}   # Populate with sources
         self.endpoints = {}  # Populate with sinks
 
-    def get_yml(self):
+    def get_yml(self, yml_path):
         '''
         Parse .yml/.yaml files and populate SECRETS
         '''
-        pass
+        try:
+            with open(yml_path) as f:
+                data = yaml.load(f, Loader=yaml.FullLoader)
+                self.SECRETS.update(data)
+        except:
+            print(".yml or .yaml file not found in specified location.")
 
     def get_env(self):
         '''
@@ -18,11 +24,7 @@ class Vortex:
         '''
         try:
             dotenv_path = find_dotenv()
-            self.SECRETS = dotenv_values(dotenv_path)
+            self.SECRETS.update(dotenv_values(dotenv_path))
         except:
             print(".env file not found in specified location.")
-
-
-v = Vortex()
-v.get_env()
 

--- a/src/vortex.py
+++ b/src/vortex.py
@@ -1,5 +1,4 @@
-from dotenv import find_dotenv
-import os
+from dotenv import find_dotenv, dotenv_values
 
 
 class Vortex:
@@ -19,21 +18,7 @@ class Vortex:
         '''
         try:
             dotenv_path = find_dotenv()
-            dotenv_file = open(dotenv_path, 'r')
-            contents = dotenv_file.readlines()
-            for line in contents:
-                variable = line.split("=")
-                key = variable[0]
-                value = variable[1]
-                if value == 'true':
-                    value = True
-                elif value == 'false':
-                    value = False
-                else:  # TODO: Define other types parsing OR use default load_dotenv
-                    value = value.replace('\n', '')
-                    value = value.replace('"', '')
-                self.SECRETS[key] = value
-                print(self.SECRETS)
+            self.SECRETS = dotenv_values(dotenv_path)
         except:
             print(".env file not found in specified location.")
 

--- a/src/vortex.py
+++ b/src/vortex.py
@@ -1,7 +1,11 @@
+from dotenv import find_dotenv
+import os
+
+
 class Vortex:
     def __init__(self):
         self.SECRETS = {}   # Populate with sources
-        self.endpoints = {} # Populate with sinks
+        self.endpoints = {}  # Populate with sinks
 
     def get_yml(self):
         '''
@@ -13,5 +17,27 @@ class Vortex:
         '''
         Parse .env files and populate secrets
         '''
-        pass
+        try:
+            dotenv_path = find_dotenv()
+            dotenv_file = open(dotenv_path, 'r')
+            contents = dotenv_file.readlines()
+            for line in contents:
+                variable = line.split("=")
+                key = variable[0]
+                value = variable[1]
+                if value == 'true':
+                    value = True
+                elif value == 'false':
+                    value = False
+                else:  # TODO: Define other types parsing OR use default load_dotenv
+                    value = value.replace('\n', '')
+                    value = value.replace('"', '')
+                self.SECRETS[key] = value
+                print(self.SECRETS)
+        except:
+            print(".env file not found in specified location.")
+
+
+v = Vortex()
+v.get_env()
 

--- a/src/vortex.py
+++ b/src/vortex.py
@@ -1,7 +1,7 @@
 class Vortex:
     def __init__(self):
         self.SECRETS = {}   # Populate with sources
-        self.endpoints = {} # Populate with sinks
+        self.endpoints = set() # Populate with sinks
 
     def get_yml(self):
         '''
@@ -15,3 +15,20 @@ class Vortex:
         '''
         pass
 
+    def register_endpoint(self, func):
+        '''
+        Registers an endpoint method to track the data flowing through its response.
+        Usage example - 
+        ```python
+        @app.GET
+        @vortex.register_endpoint
+        def response_function(...):
+            ...
+        ```
+        '''
+        def register(*args, **kwargs):
+            out = func(*args, **kwargs)
+            self.endpoints.add(out)
+            return out
+
+        return register


### PR DESCRIPTION
The `protecc init` command generates a `models.pysa` file and a `taint.config` file. Currently, both files are empty. The command also takes an option `--config-directory` where the user can provide the path where the config files must be created. Fixes #5.

### Setup instructions

1. Inside your virtual env run the below command from the project root. This will install the `protecc` command

```bash
$ pip install --editable .
```

2. Run the command

```bash
$ protecc init --config-path="./src/config"
```

### Changes made 

- Created a new file `commands.py` that will contain all the `protecc` commands.
- Added `setup.py` file for running the commands.
- Added option for providing a path where the config files should be generated.

### Screenshots

<img width="1440" alt="Screenshot 2021-02-04 at 12 11 04" src="https://user-images.githubusercontent.com/50794619/106854909-1ff93580-66e2-11eb-8145-0c0b5c6a1743.png">